### PR TITLE
ensure that method swizzling will be called once

### DIFF
--- a/OHAutoNIBi18n.m
+++ b/OHAutoNIBi18n.m
@@ -57,10 +57,14 @@ static inline void localizeUIViewController(UIViewController* vc);
 
 +(void)load
 {
-    // Autoload : swizzle -awakeFromNib with -localizeNibObject as soon as the app (and thus this class) is loaded
-	Method localizeNibObject = class_getInstanceMethod([NSObject class], @selector(localizeNibObject));
-	Method awakeFromNib = class_getInstanceMethod([NSObject class], @selector(awakeFromNib));
-	method_exchangeImplementations(awakeFromNib, localizeNibObject);
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        // Autoload : swizzle -awakeFromNib with -localizeNibObject as soon as the app (and thus this class) is loaded
+        Method localizeNibObject = class_getInstanceMethod([NSObject class], @selector(localizeNibObject));
+        Method awakeFromNib = class_getInstanceMethod([NSObject class], @selector(awakeFromNib));
+        method_exchangeImplementations(awakeFromNib, localizeNibObject);
+    });
+
 }
 
 @end


### PR DESCRIPTION
When load method is called multiple times swizzling doesn't work.
