### PR TITLE
Execute load method only once

### DIFF
--- a/OHAutoNIBi18n.m
+++ b/OHAutoNIBi18n.m
@@ -27,6 +27,7 @@ static inline void localizeUIViewController(UIViewController* vc);
 
 static NSBundle* _bundle = nil;
 static NSString* _tableName = nil;
+static BOOL _swizzled = NO;
 
 @implementation OHAutoNIBi18n
 + (void)setLocalizationBundle:(NSBundle* __nullable)bundle tableName:(NSString* __nullable)tableName {
@@ -71,11 +72,15 @@ static NSString* _tableName = nil;
 
 +(void)load
 {
+    if (_swizzled) { return; }
+
     // Autoload : swizzle -awakeFromNib with -localizeNibObject as soon as the app (and thus this class) is loaded
     Method localizeNibObject = class_getInstanceMethod([NSObject class], @selector(localizeNibObject));
     Method awakeFromNib = class_getInstanceMethod([NSObject class], @selector(awakeFromNib));
     method_exchangeImplementations(awakeFromNib, localizeNibObject);
     _bundle = [NSBundle mainBundle];
+    
+    _swizzled = YES;
 }
 
 @end

--- a/OHAutoNIBi18n.m
+++ b/OHAutoNIBi18n.m
@@ -27,7 +27,6 @@ static inline void localizeUIViewController(UIViewController* vc);
 
 static NSBundle* _bundle = nil;
 static NSString* _tableName = nil;
-static BOOL _swizzled = NO;
 
 @implementation OHAutoNIBi18n
 + (void)setLocalizationBundle:(NSBundle* __nullable)bundle tableName:(NSString* __nullable)tableName {
@@ -72,15 +71,14 @@ static BOOL _swizzled = NO;
 
 +(void)load
 {
-    if (_swizzled) { return; }
-
     // Autoload : swizzle -awakeFromNib with -localizeNibObject as soon as the app (and thus this class) is loaded
-    Method localizeNibObject = class_getInstanceMethod([NSObject class], @selector(localizeNibObject));
-    Method awakeFromNib = class_getInstanceMethod([NSObject class], @selector(awakeFromNib));
-    method_exchangeImplementations(awakeFromNib, localizeNibObject);
-    _bundle = [NSBundle mainBundle];
-    
-    _swizzled = YES;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Method localizeNibObject = class_getInstanceMethod([NSObject class], @selector(localizeNibObject));
+        Method awakeFromNib = class_getInstanceMethod([NSObject class], @selector(awakeFromNib));
+        method_exchangeImplementations(awakeFromNib, localizeNibObject);
+        _bundle = [NSBundle mainBundle];
+    });
 }
 
 @end


### PR DESCRIPTION
I encountered a problem that +[NSObject load] method called twice caused by certain framework on iOS11.
This change is code to avoid that problem.